### PR TITLE
fix: address documentation PR review feedback

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,11 +160,29 @@ jobs:
         fi
 
     - name: Generate coverage badge
-      uses: cicirello/jacoco-badge-generator@v2
       if: github.ref == 'refs/heads/main'
-      with:
-        coverage-badge-filename: coverage.svg
-        generate-coverage-badge: true
+      run: |
+        # Extract coverage percentage from vitest coverage JSON
+        COVERAGE=$(node -e "
+          const summary = require('./coverage/coverage-summary.json');
+          const total = summary.total;
+          const pct = (total.lines.pct + total.statements.pct + total.functions.pct + total.branches.pct) / 4;
+          console.log(Math.round(pct));
+        ")
+        
+        # Generate badge URL using shields.io
+        BADGE_COLOR="red"
+        if [ "$COVERAGE" -ge 80 ]; then
+          BADGE_COLOR="green"
+        elif [ "$COVERAGE" -ge 60 ]; then
+          BADGE_COLOR="yellow"
+        fi
+        
+        echo "Coverage: ${COVERAGE}%"
+        echo "Badge color: ${BADGE_COLOR}"
+        
+        # Create coverage badge using shields.io
+        curl -s "https://img.shields.io/badge/coverage-${COVERAGE}%25-${BADGE_COLOR}" > coverage.svg
 
 
   lint-check:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 - [Installation](#installation)
 - [Quick start](#quick-start)
 - [API surface](#api-surface)
-- [React hook (alpha)](#react-hook-alpha)
 - [Throw-ban in 60 seconds](#throw-ban-in-60-seconds)
   - [1. Add the rule](#1-add-the-rule)
   - [2. Hook into CI](#2-hook-into-ci)
@@ -90,26 +89,8 @@ class ZeroError extends Error {
 - **[API Reference](docs/api/)** - Complete API documentation with TypeScript types
 - **[Tutorials](docs/tutorials/)** - Step-by-step guides from basics to advanced patterns
 - **[Examples](docs/examples/)** - Real-world code examples (Express, React, file processing)
+- **[React Hook](docs/api/react.md)** - useResult hook for React applications
 - **[Migration Guide](docs/guides/migration-guide.md)** - Migrate from try/catch or other libraries
-
----
-## React hook (alpha)
-
-```typescript
-import { useResult } from "@flyingrobots/zerothrow/react";
-
-function Profile({ id }: { id: string }) {
-    const { state, data, error } = useResult(
-        () => api.fetchProfile(id), [id]
-    );
-
-    if (state === "loading") return <Spinner />;
-    
-    if (state === "err") return <ErrorView code={error!.code} />;
-    
-    return <ProfileCard user={data!} />;
-}
-```
 
 ---
 ## Throw-ban in 60 seconds

--- a/docs/api/eslint.md
+++ b/docs/api/eslint.md
@@ -14,7 +14,7 @@ npm install @flyingrobots/zerothrow
 
 ### .eslintrc.json
 
-```json
+```jsonc
 {
   "extends": [
     // Your other extends...
@@ -181,7 +181,7 @@ interface NoThrowOptions {
 
 Allow throw statements in test files (default: `false`).
 
-```json
+```jsonc
 {
   "@flyingrobots/zerothrow/no-throw": ["error", {
     "allowInTests": true
@@ -198,7 +198,7 @@ This allows throws in files matching common test patterns:
 
 Array of regex patterns for files where throws are allowed.
 
-```json
+```jsonc
 {
   "@flyingrobots/zerothrow/no-throw": ["error", {
     "allowedPatterns": [
@@ -213,7 +213,7 @@ Array of regex patterns for files where throws are allowed.
 
 Custom error message to display.
 
-```json
+```jsonc
 {
   "@flyingrobots/zerothrow/no-throw": ["error", {
     "message": "Use Result types instead of throwing. See: https://docs.example.com/error-handling"
@@ -238,7 +238,7 @@ When you encounter a violation, consider:
 
 Start by enabling the rule as a warning:
 
-```json
+```jsonc
 {
   "rules": {
     "@flyingrobots/zerothrow/no-throw": "warn"

--- a/docs/api/react.md
+++ b/docs/api/react.md
@@ -388,7 +388,7 @@ function SearchableList() {
         onChange={setQuery}
         placeholder="Search..."
       />
-      {loading && <SearchingIndicator />}
+      {loading && <SearchIndicator />}
       {error && <ErrorMessage error={error} />}
       {data && (
         <SearchResults

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -9,7 +9,9 @@ Browser-based playground to experiment with ZeroThrow:
 - Live code editor with syntax highlighting
 - Pre-built examples for common patterns
 - Real-time console output
-- No setup required - just open in browser
+- No setup required - **open locally in your browser**
+
+> **Note**: The playground is a standalone HTML file. Download and open it locally for the best experience.
 
 ### 2. [Express API](./express-api.ts)
 Complete REST API implementation with:

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -1,0 +1,117 @@
+/**
+ * Creating a sidebar enables you to:
+ - create an ordered group of docs
+ - render a sidebar for each doc of that group
+ - provide next/previous navigation
+
+ The sidebars can be generated from the filesystem, or explicitly defined here.
+
+ Create as many sidebars as you want.
+ */
+
+// @ts-check
+
+/** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */
+const sidebars = {
+  // Main documentation sidebar
+  docs: [
+    {
+      type: 'category',
+      label: 'Getting Started',
+      items: [
+        'introduction',
+        'installation',
+        'quickstart',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'API Reference',
+      items: [
+        'api/README',
+        'api/core-types',
+        'api/core-functions',
+        'api/combinators',
+        'api/react',
+        'api/eslint',
+        'api/type-utilities',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Tutorials',
+      items: [
+        'tutorials/01-getting-started',
+        'tutorials/02-advanced-patterns',
+        'tutorials/03-error-handling',
+        'tutorials/04-functional-programming',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Examples',
+      items: [
+        'examples/README',
+        'examples/interactive-playground',
+        'examples/express-api',
+        'examples/file-processor',
+        'examples/react-form',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Guides',
+      items: [
+        'guides/migration-guide',
+        'guides/performance',
+        'guides/best-practices',
+        'guides/githooks',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Reference',
+      items: [
+        'contributing',
+        'license',
+        'changelog',
+      ],
+    },
+  ],
+
+  // Separate sidebar for API docs if needed
+  api: [
+    {
+      type: 'doc',
+      id: 'api/README',
+      label: 'Overview',
+    },
+    {
+      type: 'category',
+      label: 'Core',
+      collapsed: false,
+      items: [
+        'api/core-types',
+        'api/core-functions',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Advanced',
+      items: [
+        'api/combinators',
+        'api/type-utilities',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Integrations',
+      items: [
+        'api/react',
+        'api/eslint',
+      ],
+    },
+  ],
+};
+
+module.exports = sidebars;


### PR DESCRIPTION
## Summary
- Addresses all feedback from the documentation PR review
- Fixes the JaCoCo badge generator issue that was causing build failures

## Changes
1. ✅ Removed React hook section from main README (now properly linked to API docs)
2. ✅ Added note about opening interactive-playground.html locally
3. ✅ Changed JSON code blocks to jsonc format in eslint.md for comment support
4. ✅ Fixed SearchingIndicator → SearchIndicator typo in react.md
5. ✅ Added docs/sidebars.js scaffold for future Docusaurus migration
6. ✅ Fixed GitHub workflow to use Vitest coverage instead of JaCoCo

## JaCoCo Fix Details
The test workflow was using `cicirello/jacoco-badge-generator@v2` which is designed for Java projects. This TypeScript project uses Vitest for coverage reporting. The fix:
- Reads coverage from Vitest's `coverage-summary.json`
- Generates badge using shields.io
- Properly handles JavaScript coverage format

## Testing
- All documentation changes are formatting/content fixes
- The workflow fix prevents the build failure seen after merging the docs branch

🤖 Generated with [Claude Code](https://claude.ai/code)